### PR TITLE
Document one-argument forms of to_json and from_json

### DIFF
--- a/lib/JSON/MaybeXS.pm
+++ b/lib/JSON/MaybeXS.pm
@@ -171,10 +171,29 @@ module, and takes a string of JSON text to deserialise to a perl data structure.
 
   my $data_structure = decode_json($json_text);
 
-=head2 to_json, from_json
+=head2 to_json
 
-See L<JSON> for details.  These are included to support legacy code
-B<only>.
+This function is equivalent to calling C<< JSON()->new->encode($data_structure) >>.
+It takes a perl data structure which is serialised to JSON text without encoding
+it to UTF-8. You should only use this function if you expect another layer to
+handle the UTF-8 encoding of the resulting JSON text.
+
+  my $json_text = to_json($data_structure);
+
+Additional arguments can be passed and will be handled as in L<JSON/to_json>,
+this is included to support legacy code B<only>.
+
+=head2 from_json
+
+This function is equivalent to calling C<< JSON()->new->decode($json_text) >>. It
+takes a string of unencoded JSON text to deserialise to a perl data structure. You
+should only use this function if another layer is already handling the UTF-8
+decoding of the input JSON text.
+
+  my $data_structure = from_json($json_text);
+
+Additional arguments can be passed and will be handled as in L<JSON/from_json>,
+this is included to support legacy code B<only>.
 
 =head2 JSON
 


### PR DESCRIPTION
There are many legitimate use cases for encoding/decoding JSON without handling character encoding at that layer (for example in webapps or templates which handle encoding themselves), so it should be an operation supported by this module similarly to Mojo::JSON (ideally, the lower level JSON modules would also provide optimized functions to re-export, but this is not currently the case). The to_json and from_json functions provided by this module for legacy support are perfectly usable and straightforward (with proper documentation) for this use case, as long as a second argument is not provided; the two argument form still should not be supported.